### PR TITLE
Fix worker operation count should use the correct count

### DIFF
--- a/client.go
+++ b/client.go
@@ -146,7 +146,7 @@ func (self *ClientBase) Main() {
 		if i < (opCount % threadCount) {
 			threadOpCount++
 		}
-		worker := NewWorker(db, workload, props, self.DoTransactions, opCount, targetPerThreadPerMS, workerCh, resultCh)
+		worker := NewWorker(db, workload, props, self.DoTransactions, threadOpCount, targetPerThreadPerMS, workerCh, resultCh)
 		workers = append(workers, worker)
 		go worker.run()
 	}


### PR DESCRIPTION
The worker's operation count should use the thread operation count = (total operation count) / (thread count).  